### PR TITLE
Fix pmrails-cmpexe gem PATH, convert to script, and add usage checks

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -27,10 +27,13 @@ PmRailsは以下のコマンドを提供します。
   **使用方法**: `pmrails-init [OPTIONS]`
 
 - **`pmrails-run`**: プロジェクトローカルなランタイムディレクトリを持つ単一のRailsコンテナ内で任意のコマンドを実行します。\
-  **使用方法**: `pmrails-run COMMAND [OPTIONS]`
+  **使用方法**: `pmrails-run COMMAND [ARG...]`
 
 - **`pmrails-compose`**: `podman-compose`のラッパーとして、プロジェクトのCompose環境を操作します。\
   **使用方法**: `pmrails-compose [GLOBAL_OPTIONS] COMMAND [COMMAND_OPTIONS]`
+
+- **`pmrails-cmpexe`**: プロジェクトのCompose環境のRailsコンテナ内で任意のコマンドを実行します。\
+  **使用方法**: `pmrails-cmpexe COMMAND [ARG...]`
 
 ### 非推奨コマンド
 
@@ -90,10 +93,10 @@ exec $SHELL -l
 
 PmRailsには、よく使われるコマンドを短く書くためのエイリアスを定義した`aliases`ファイルが同梱されています。
 
-これを読み込むと、以下のような長いコマンドを
+これを読み込むと、以下のようなコマンドを
 
 ```sh
-pmrails-compose exec rails-app bin/rails console
+pmrails-cmpexe bin/rails console
 ```
 
 次のように短く書けます。
@@ -114,8 +117,7 @@ exec $SHELL -l
 ```sh
 # pmrails aliases
 alias pmrails-rrails='pmrails-run bin/rails'
-alias pmrails-crails='pmrails-compose exec rails-app bin/rails'
-alias pmrails-cmpexe='pmrails-compose exec rails-app'
+alias pmrails-crails='pmrails-cmpexe bin/rails'
 ```
 
 
@@ -237,7 +239,7 @@ gemは、`pmrails-run`と同じように、PmRailsが管理するgemストアを
 このモードでは、Compose環境を「使い捨てのコンテナ」ではなく、「長く使い続けるワークスペース」と考えてください。
 通常は一度立ち上げ（up）、稼働中に多くの`exec`コマンドを実行し、作業を中断したいときには停止（stop）し、再開するときには起動（start）し、最終的に不要になったら破棄（down）します。
 
-このモデルには重要なルールが1つあります。Composeを使って作業している間は、Rails関連コマンドを`pmrails-run`ではなく、`pmrails-compose exec rails-app ...`を通じて実行してください。
+このモデルには重要なルールが1つあります。Composeを使って作業している間は、Rails関連コマンドを`pmrails-run`ではなく、`pmrails-cmpexe ...`を通じて実行してください。
 `pmrails-run`は隔離されたコンテナで実行するため、Composeによって管理されているデータベースやSelenium、その他のサービスと通信することができません。
 
 #### プロジェクトの準備
@@ -275,7 +277,7 @@ pmrails-init --database=postgresql
 通常の作業の流れは以下のとおりです。
 
 1. `pmrails-compose up -d`で環境を立ち上げます。
-2. 環境稼働中に`pmrails-compose exec rails-app ...`で作業を行います。
+2. 環境稼働中に`pmrails-cmpexe ...`で作業を行います。
 3. 中断したいときは`pmrails-compose stop`で環境を一時停止します。
 4. `pmrails-compose start`で環境を再開します。
 5. 作業が完了したら`pmrails-compose down`で環境を破棄します。
@@ -292,16 +294,15 @@ pmrails-compose up -d
 環境が稼働したら、`exec`で作業を行います。
 
 ```sh
-pmrails-compose exec rails-app bundle install
-pmrails-compose exec rails-app bin/rails db:migrate
-pmrails-compose exec rails-app bin/rails console
-pmrails-compose exec rails-app bin/rails server
+pmrails-cmpexe bundle install
+pmrails-cmpexe bin/rails db:migrate
+pmrails-cmpexe bin/rails console
+pmrails-cmpexe bin/rails server
 ```
 
-エイリアスを設定している場合、同じコマンドを以下のように実行できます。
+エイリアスを設定している場合、後ろ3つのコマンドを以下のように実行できます。
 
 ```sh
-pmrails-cmpexe bundle install
 pmrails-crails db:migrate
 pmrails-crails console
 pmrails-crails server
@@ -500,7 +501,7 @@ PMRAILS_PROJECT_NAME="sample_app"
 
 > **重要:** このファイルを変更または置き換える際には、**Railsコンテナのサービス名として必ず`rails-app`を使用してください**。PmRailsの内部コマンドや自動生成される設定は、このサービス名を前提に機能します。
 
-> **注意:** `rails-app`サービスの`volumes`、`environment`、または`entrypoint`の設定に関して、設定値を追加するのではなく、完全に上書きしてしまうと、自動Gem共有が機能しなくなる原因となります。これらをカスタマイズする必要がある場合は、`share/compose.base.yaml`を確認し、PmRails内部で必要となるマッピングを維持するようにしてください。
+> **注意:** `rails-app`サービスの`volumes`または`environment`の設定に関して、設定値を追加するのではなく、完全に上書きしてしまうと、自動Gem共有が機能しなくなる原因となります。これらをカスタマイズする必要がある場合は、`share/compose.base.yaml`を確認し、PmRails内部で必要となるマッピングを維持するようにしてください。
 
 
 ## `.pmrails` — ローカルディレクトリとコンテナ内の環境変数

--- a/README.md
+++ b/README.md
@@ -28,10 +28,13 @@ PmRails provides the following commands:
   **Usage**: `pmrails-init [OPTIONS]`
 
 - **`pmrails-run`**: Runs an arbitrary command inside a single Rails container with project-local runtime directories.\
-  **Usage**: `pmrails-run COMMAND [OPTIONS]`
+  **Usage**: `pmrails-run COMMAND [ARG...]`
 
 - **`pmrails-compose`**: Wraps `podman-compose` to operate the project's Compose environment.\
   **Usage**: `pmrails-compose [GLOBAL_OPTIONS] COMMAND [COMMAND_OPTIONS]`
+
+- **`pmrails-cmpexe`**: Runs an arbitrary command inside a Rails container in the project's Compose environment.\
+  **Usage**: `pmrails-cmpexe COMMAND [ARG...]`
 
 ### Deprecated Commands
 
@@ -90,10 +93,10 @@ exec $SHELL -l
 ### (Optional) Set Up Aliases
 
 PmRails ships with a small `aliases` file that defines shorthand aliases for the most common invocations.
-Sourcing it lets you replace long commands like:
+Sourcing it lets you replace commands like:
 
 ```sh
-pmrails-compose exec rails-app bin/rails console
+pmrails-cmpexe bin/rails console
 ```
 
 with shorter ones like:
@@ -114,8 +117,7 @@ This adds the following aliases:
 ```sh
 # pmrails aliases
 alias pmrails-rrails='pmrails-run bin/rails'
-alias pmrails-crails='pmrails-compose exec rails-app bin/rails'
-alias pmrails-cmpexe='pmrails-compose exec rails-app'
+alias pmrails-crails='pmrails-cmpexe bin/rails'
 ```
 
 
@@ -234,7 +236,7 @@ Gems use the same managed PmRails gem store as `pmrails-run`, so the host Ruby e
 In this mode, think of the Compose environment as a long-lived workspace, not a one-shot container.
 You usually bring it up once, run many `exec` commands while it is running, stop it when you want to pause, start it again when you return, and finally tear it down when you are done.
 
-One important rule follows from that model: once you are working with Compose, run your day-to-day Rails commands through `pmrails-compose exec rails-app ...`, not `pmrails-run`.
+One important rule follows from that model: once you are working with Compose, run your day-to-day Rails commands through `pmrails-cmpexe ...`, not `pmrails-run`.
 `pmrails-run` starts an isolated container and cannot talk to the database, Selenium, or other services managed by Compose.
 
 #### Prepare the Project
@@ -272,7 +274,7 @@ It also patches `test/application_system_test_case.rb` (when present) so that sy
 The usual workflow is:
 
 1. Bring the environment up with `pmrails-compose up -d`.
-2. Do your work with `pmrails-compose exec rails-app ...` while it is running.
+2. Do your work with `pmrails-cmpexe ...` while it is running.
 3. Pause it with `pmrails-compose stop` when you want to come back later.
 4. Resume it with `pmrails-compose start`.
 5. Remove it with `pmrails-compose down` when you are done.
@@ -289,16 +291,15 @@ If the services do not exist yet, `up` creates them. If they already exist but a
 Once the environment is running, do your work with `exec`:
 
 ```sh
-pmrails-compose exec rails-app bundle install
-pmrails-compose exec rails-app bin/rails db:migrate
-pmrails-compose exec rails-app bin/rails console
-pmrails-compose exec rails-app bin/rails server
+pmrails-cmpexe bundle install
+pmrails-cmpexe bin/rails db:migrate
+pmrails-cmpexe bin/rails console
+pmrails-cmpexe bin/rails server
 ```
 
-If you use the aliases, the same commands become:
+If you use the aliases, the last three commands become:
 
 ```sh
-pmrails-cmpexe bundle install
 pmrails-crails db:migrate
 pmrails-crails console
 pmrails-crails server
@@ -493,7 +494,7 @@ If `.pmrails/compose.yaml` exists, `pmrails-compose` layers it on top of an inte
 
 > **Important:** When modifying or replacing this file, **you must use `rails-app` as the service name for your Rails container**. PmRails internal commands and auto-generated configurations explicitly rely on this exact service name to function correctly.
 
-> **Note:** Completely overriding the `volumes`, `environment`, or `entrypoint` settings of the `rails-app` service (rather than appending to them) will break automatic gem sharing. If you need to customize these, review `share/compose.base.yaml` to ensure you preserve the required PmRails internal mappings.
+> **Note:** Completely overriding the `volumes` or `environment` settings of the `rails-app` service (rather than appending to them) will break automatic gem sharing. If you need to customize these, review `share/compose.base.yaml` to ensure you preserve the required PmRails internal mappings.
 
 ## `.pmrails` — Local Directory and In-Container Environment Variables
 
@@ -537,7 +538,7 @@ Installed gems are reused when both of these match:
 
 Volumes without an ABI suffix, such as `pmrails-gem_home-3.4.8`, use the official Ruby image ABI. If you consistently use official Ruby images, this should work automatically.
 
-When mixing different images or host platforms, the core rule is: **the same ABI suffix must guarantee native-extension compatibility.** 
+When mixing different images or host platforms, the core rule is: **the same ABI suffix must guarantee native-extension compatibility.**
 
 If `PMRAILS_GEM_HOME_ABI` is unset, PmRails automatically derives the ABI suffix from the image tag. It removes a leading numeric Ruby-version prefix and one optional following `-`, while leaving other text in place to avoid merging incompatible gem stores too aggressively. For example, `3.4.8-trixie` becomes `trixie`.
 

--- a/aliases
+++ b/aliases
@@ -1,5 +1,4 @@
 
 # pmrails aliases
 alias pmrails-rrails='pmrails-run bin/rails'
-alias pmrails-crails='pmrails-compose exec rails-app bin/rails'
-alias pmrails-cmpexe='pmrails-compose exec rails-app'
+alias pmrails-crails='pmrails-cmpexe bin/rails'

--- a/bin/pmrails-cmpexe
+++ b/bin/pmrails-cmpexe
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ "$#" -lt 1 ]; then
+    printf 'Usage: %s\n' 'pmrails-cmpexe COMMAND [ARG...]' >&2
+    exit 1
+fi
+
+_PMRAILS_SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+exec "${_PMRAILS_SCRIPT_DIR}/pmrails-compose" exec rails-app /pmrails-entrypoint "$@"

--- a/bin/pmrails-run
+++ b/bin/pmrails-run
@@ -1,6 +1,11 @@
 #!/bin/sh
 set -eu
 
+if [ "$#" -lt 1 ]; then
+    printf 'Usage: %s\n' 'pmrails-run COMMAND [ARG...]' >&2
+    exit 1
+fi
+
 _PMRAILS_SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
 # shellcheck source=./lib/pmrails.sh
 . "${_PMRAILS_SCRIPT_DIR}/../lib/pmrails.sh"

--- a/share/compose.base.yaml
+++ b/share/compose.base.yaml
@@ -11,7 +11,6 @@ services:
       - ${PWD}:/x
       - ${_PMRAILS_VOLUME_NAME}:${_PMRAILS_GEM_HOME}
       - ${_PMRAILS_SCRIPT_DIR}/../share/entrypoint:/pmrails-entrypoint:ro,z
-    entrypoint: /pmrails-entrypoint
     working_dir: /x
     environment:
       GEM_HOME: ${_PMRAILS_GEM_HOME}


### PR DESCRIPTION
- Fixes an issue where `pmrails-cmpexe` (previously an alias) bypassed the entrypoint, resulting in the gem bin directory not being in the PATH.
- Promotes `pmrails-cmpexe` to a formal shell script to inject `/pmrails-entrypoint` during `compose exec`.
- Adds a missing argument validation (Usage message) to `pmrails-cmpexe` and `pmrails-run` for better UX.